### PR TITLE
Make `lint` a dev dependency

### DIFF
--- a/pubspec.lock
+++ b/pubspec.lock
@@ -68,7 +68,7 @@ packages:
     source: sdk
     version: "0.0.0"
   lint:
-    dependency: "direct main"
+    dependency: "direct dev"
     description:
       name: lint
       url: "https://pub.dartlang.org"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -12,14 +12,12 @@ dependencies:
   flutter:
     sdk: flutter
 
-  lint: ^1.4.0-dev.d210.1
   cupertino_icons: ^0.1.3
 
 dev_dependencies:
   flutter_test:
     sdk: flutter
+  lint: ^1.4.0-dev.d210.1
 
 flutter:
   uses-material-design: true
-
-


### PR DESCRIPTION
`lint` should be a dev dependency, not a normal one.